### PR TITLE
Replace deprecated .dataobj by .get_data() for nibabel

### DIFF
--- a/py-client/aas_tests.json
+++ b/py-client/aas_tests.json
@@ -16,7 +16,7 @@
       "name": "test_segmentation_spleen",
       "disabled": false,
       "api": "segmentation",
-      "model": "segmentation_spleen",
+      "model": "segmentation_ct_spleen",
       "image": "test-data/image.nii.gz",
       "result_prefix": "test-data/output/segmentation_spleen",
       "params": "{}"
@@ -25,7 +25,7 @@
       "name": "test_annotation_spleen",
       "disabled": false,
       "api": "dextr3d",
-      "model": "annotation_spleen",
+      "model": "annotation_ct_spleen",
       "image": "test-data/image.nii.gz",
       "result_prefix": "test-data/output/annotation_spleen",
       "params": "{\"points\":\"[[93,106,64],[40,108,64],[29,66,64],[47,20,64],[93,32,64],[99,68,64]]\"}",

--- a/py-client/client_api.py
+++ b/py-client/client_api.py
@@ -131,7 +131,7 @@ class AIAAClient:
         # Read image
         image = nib.load(image_file_path)
         affine = image.affine
-        image = image.dataobj
+        image = image.get_data()
         orig_size = np.shape(image)
         spacing = [abs(affine[(0, 0)]), abs(affine[(1, 1)]), abs(affine[(2, 2)])]
 
@@ -289,7 +289,7 @@ def _image_post_processing(roi_image_file_path, crop, orig_size):
     result = np.zeros(orig_size, np.uint8)
 
     roi_result = nib.load(roi_image_file_path)
-    roi_result = roi_result.dataobj
+    roi_result = roi_result.get_data()
 
     orig_crop_size = [crop[0][1] - crop[0][0],
                       crop[1][1] - crop[1][0],

--- a/py-client/client_api.py
+++ b/py-client/client_api.py
@@ -298,7 +298,7 @@ def _image_post_processing(roi_image_file_path, crop, orig_size):
     resize_image = resize(roi_result, orig_crop_size, preserve_range=True, order=0)
 
     result[crop[0][0]:crop[0][1], crop[1][0]:crop[1][1], crop[2][0]:crop[2][1]] = resize_image
-    return _get_largest_cc(result)
+    return result
 
 
 def _get_largest_cc(result):

--- a/py-client/client_api.py
+++ b/py-client/client_api.py
@@ -295,7 +295,7 @@ def _image_post_processing(roi_image_file_path, crop, orig_size):
                       crop[1][1] - crop[1][0],
                       crop[2][1] - crop[2][0]]
 
-    resize_image = resize(roi_result, orig_crop_size, order=0)
+    resize_image = resize(roi_result, orig_crop_size, preserve_range=True, order=0)
 
     result[crop[0][0]:crop[0][1], crop[1][0]:crop[1][1], crop[2][0]:crop[2][1]] = resize_image
     return _get_largest_cc(result)


### PR DESCRIPTION
In nibabel .dataobj is deprecated hence use .get_data() method as recommended

@holgerroth 