### PR TITLE
Use AIAA client APIs from py-client

### DIFF
--- a/slicer-plugin/NvidiaAIAA/.gitignore
+++ b/slicer-plugin/NvidiaAIAA/.gitignore
@@ -1,0 +1,1 @@
+AIAAClient.py

--- a/slicer-plugin/NvidiaAIAA/AIAAClient.py
+++ b/slicer-plugin/NvidiaAIAA/AIAAClient.py
@@ -1,0 +1,1 @@
+../../py-client/client_api.py

--- a/slicer-plugin/NvidiaAIAA/AIAAClient.py
+++ b/slicer-plugin/NvidiaAIAA/AIAAClient.py
@@ -1,1 +1,0 @@
-../../py-client/client_api.py

--- a/slicer-plugin/NvidiaAIAA/SegmentEditorNvidiaAIAA.py
+++ b/slicer-plugin/NvidiaAIAA/SegmentEditorNvidiaAIAA.py
@@ -24,6 +24,11 @@ class SegmentEditorNvidiaAIAA(ScriptedLoadableModule):
         slicer.app.connect("startupCompleted()", self.registerEditorEffect)
 
     def registerEditorEffect(self):
+        import shutil
+        pluginDir = os.path.dirname(__file__)
+        logging.info('This plugin dir: {}'.format(pluginDir))
+        shutil.copy(pluginDir + '/../../py-client/client_api.py', pluginDir + '/AIAAClient.py')
+
         import qSlicerSegmentationsEditorEffectsPythonQt as qSlicerSegmentationsEditorEffects
         instance = qSlicerSegmentationsEditorEffects.qSlicerSegmentEditorScriptedEffect(None)
         effectFilename = os.path.join(os.path.dirname(__file__), self.__class__.__name__ + 'Lib/SegmentEditorEffect.py')


### PR DESCRIPTION
@jcfr @bsmarine 

Idea is to use python client APIs already part of the repository.  Instead of writing the same logic here.
The python client APIs in AIAAClient are compatible for python 2.x and 3.x

Currently I have created a symlink for  ../../py-client/client_api.py -> slicer-plugin/NvidiaAIAA/AIAAClient.py

I couldn't find a better option for now... but may not work for windows.. let me know if you have a better way to import the module AIAAClient from py-client/client_api.py into Plugin
