### PR TITLE
Fix Slicer extension build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,15 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set(AIAA_LOG_DEBUG_ENABLED "0" CACHE STRING "Enable Debug Level logs for AIAA Client")
 set(AIAA_LOG_INFO_ENABLED  "1" CACHE STRING "Enable Info Level logs for AIAA Client")
 
+# 3D Slicer's extension build tool defines NvidiaAIAssistedAnnotation_BUILD_SLICER_EXTENSION:BOOL=ON
+# to indicate that this project is being built as a 3D Slicer extension.
+if (NvidiaAIAssistedAnnotation_BUILD_SLICER_EXTENSION)
+  message(STATUS "Building project as a Slicer extension")
+  project(NvidiaAIAssistedAnnotation)
+  add_subdirectory(slicer-plugin)
+  return()
+endif()
+
 if (NOT DEFINED USE_SUPERBUILD)
   project(NvidiaAIAAClient-superbuild)
   include (cpp-client/CMakeExternals/SuperBuild.cmake)

--- a/slicer-plugin/CMakeLists.txt
+++ b/slicer-plugin/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(NvidiaAIAssistedAnnotation)
-
 #-----------------------------------------------------------------------------
 # Extension meta-information
 set(EXTENSION_HOMEPAGE "https://github.com/NVIDIA/ai-assisted-annotation-client/tree/master/slicer-plugin")
@@ -11,7 +9,6 @@ set(EXTENSION_DESCRIPTION "This extension offers automatic segmentation using NV
 set(EXTENSION_ICONURL "https://raw.githubusercontent.com/NVIDIA/ai-assisted-annotation-client/master/slicer-plugin/NvidiaAIAssistedAnnotation.png")
 set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/NVIDIA/ai-assisted-annotation-client/master/slicer-plugin/snapshot.png")
 set(EXTENSION_DEPENDS "NA") # Specified as a space separated string, a list or 'NA' if any
-set(EXTENSION_BUILD_SUBDIRECTORY "slicer-plugin")
 
 #-----------------------------------------------------------------------------
 # Extension dependencies

--- a/slicer-plugin/README.md
+++ b/slicer-plugin/README.md
@@ -34,3 +34,4 @@ The plugin can be downloaded and installed directly from GitHub:
 - Open 3D Slicer: Go to Edit -> Application Settings -> Modules -> Additional Module Paths
    1) Add New Module Path: <FULL_PATH>/slicer-plugin/NvidiaAIAA
    2) Restart
+- To build extension package, build 3D Slicer then configure ai-assisted-annotation-client project using CMake, defining these variables: -DSlicer_DIR:PATH=... -DNvidiaAIAssistedAnnotation_BUILD_SLICER_EXTENSION:BOOL=ON


### PR DESCRIPTION
This fix is needed to be able to build the project as a Slicer extension (previous attempt of using build subdirectory did not work, as it would have needed setting up superbuild to generate a project in a subdirectory in the build folder).