### PR TITLE
re #41: Add missing files to the Slicer extension package

### DIFF
--- a/slicer-plugin/NvidiaAIAA/CMakeLists.txt
+++ b/slicer-plugin/NvidiaAIAA/CMakeLists.txt
@@ -19,6 +19,8 @@ set(MODULE_PYTHON_SCRIPTS
 
 set(MODULE_PYTHON_RESOURCES
   ${MODULE_NAME}Lib/SegmentEditorEffect.png
+  ${MODULE_NAME}Lib/nvidia-icon.png
+  ${MODULE_NAME}Lib/edit-icon.png
   )
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
This fixes missing icons on buttons when the Slicer plugin is installed via Slicer's extension manager.
