### PR TITLE
Fix doc_id to avoid going into stale mode..

### DIFF
--- a/py-client/client_api.py
+++ b/py-client/client_api.py
@@ -135,6 +135,7 @@ class AIAAClient:
         logger.debug('Using Fields: {}'.format(fields))
         logger.debug('Using Files: {}'.format(files))
 
+        self.doc_id = None
         form, files = AIAAUtils.http_post_multipart(self.server_url, selector, fields, files)
         form = json.loads(form) if isinstance(form, str) else form
 

--- a/slicer-plugin/NvidiaAIAA/SegmentEditorNvidiaAIAALib/SegmentEditorEffect.py
+++ b/slicer-plugin/NvidiaAIAA/SegmentEditorNvidiaAIAALib/SegmentEditorEffect.py
@@ -714,7 +714,7 @@ class AIAALogic():
         self.reportProgress(30)
 
         result_file = tempfile.NamedTemporaryFile(suffix=self.outputFileExtension(), dir=self.aiaa_tmpdir).name
-        params = self.aiaaClient.segmentation(model, in_file, result_file, save_doc=True)
+        params = self.aiaaClient.segmentation(model, in_file, result_file, save_doc=False)
 
         extreme_points = params.get('points', params.get('extreme_points'))
         logging.debug('Extreme Points: {}'.format(extreme_points))


### PR DESCRIPTION
Slicer/Client if kept for longer time, the doc session gets stale and invalid... you have to restart the client..
Avoid this condition to go into stale mode... get doc_id always from a valid response..