### PR TITLE
Update default Slicer segmentation server address

### DIFF
--- a/slicer-plugin/NvidiaAIAA/SegmentEditorNvidiaAIAALib/SegmentEditorEffect.py
+++ b/slicer-plugin/NvidiaAIAA/SegmentEditorNvidiaAIAALib/SegmentEditorEffect.py
@@ -84,7 +84,7 @@ class SegmentEditorEffect(AbstractScriptedSegmentEditorEffect):
         serverUrl = self.ui.serverComboBox.currentText
         if not serverUrl:
             # Default Slicer AIAA server
-            serverUrl = "http://perklabseg.asuscomm.com:5000"
+            serverUrl = "http://perklabseg.cs.queensu.ca:5000"
         return serverUrl
 
     def setupOptionsFrame(self):


### PR DESCRIPTION
The default NVIDIA AIAA segmentation server for Slicer was moved to a new location, therefore we need to update the server address.